### PR TITLE
Add group to SecurityContextConstraints apiVersion

### DIFF
--- a/scc-tutorial-scc.yaml
+++ b/scc-tutorial-scc.yaml
@@ -1,5 +1,5 @@
 kind: SecurityContextConstraints
-apiVersion: v1
+apiVersion: security.openshift.io/v1
 metadata:
   name: scc-tutorial-scc
 allowPrivilegedContainer: false


### PR DESCRIPTION
Support for using `v1` without a group in `apiVersion` was removed in OpenShift Container Platform 4.9, see [release notes](https://docs.openshift.com/container-platform/4.9/release_notes/ocp-4-9-release-notes.html#ocp-4-9-deprecated-removed-features). Adding `security.openshift.io` to allow this example to be valid on OCP 4.9 and later.